### PR TITLE
check for operation fails in append_to_list | cleaned MakeFile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .vscode/
 build/
-coverage.info
 report/

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ cov: $(BUILD_DIR)/main
 	@./$(BUILD_DIR)/main
 	@gcov $(SOURCES) -o $(BUILD_DIR)
 	@mv *.gcov $(BUILD_DIR)
-	@mkdir $(REPORT_DIR)
+	@mkdir -p $(REPORT_DIR)
 	@lcov --capture --directory $(BUILD_DIR) --output-file $(REPORT_DIR)/coverage.info
 	@genhtml $(REPORT_DIR)/coverage.info --output-directory $(REPORT_DIR)
 

--- a/Makefile
+++ b/Makefile
@@ -35,17 +35,17 @@ $(BUILD_DIR)/%.o: %.c
 	@mkdir -p $(BUILD_DIR)
 	$(CC) $(CFLAGS) $(COVERAGE_CFLAGS) -I. -c $< -o $@
 
-.PHONY: cov clean
+.PHONY: clean
 
 cov: $(BUILD_DIR)/main
 	@echo "$(COLOR_GREEN)============ RUNNING MAIN PROGRAM ============$(COLOR_RESET)"
 	@./$(BUILD_DIR)/main
 	@gcov $(SOURCES) -o $(BUILD_DIR)
 	@mv *.gcov $(BUILD_DIR)
+	@mkdir $(REPORT_DIR)
 	@lcov --capture --directory $(BUILD_DIR) --output-file $(REPORT_DIR)/coverage.info
 	@genhtml $(REPORT_DIR)/coverage.info --output-directory $(REPORT_DIR)
 
 clean:
 	@echo "$(COLOR_YELLOW)============ CLEANING ============$(COLOR_RESET)"
 	rm -rf $(BUILD_DIR) $(REPORT_DIR)
-	rm -f $(REPORT_DIR)/coverage.info $(BUILD_DIR)/*.gcov

--- a/list.c
+++ b/list.c
@@ -52,20 +52,34 @@ unsigned count_nodes(Head* head)
     return count;
 }
 
-void append_to_list(Head* head, unsigned size, void* data) // TODO: how would I know if my operation fails? return type should be bool
+int append_to_list(Head* head, unsigned size, void* data)
 {
-    if(head) {
-        if(!(head->front)) {
+    if (head) 
+    {
+        if (!(head->front)) 
+        {
             head->front = create_node();
             fill_node_data(head->front, size, data);
-        } else {
-            Node* this_node  = head->front;
-            Node* next_node = get_next_node(this_node);
-            while(next_node) {
+        } 
+        else 
+        {
+            Node *this_node = head->front;
+            Node *next_node = get_next_node(this_node);
+            while (next_node) 
+            {
                 this_node = next_node;
                 next_node = get_next_node(next_node);
             }
-            append_node(this_node, size, data);
+            if (append_node(this_node, size, data)) 
+            {
+                return 1;
+            } 
+            else 
+            {
+                return 0;
+            }
         }
+        return 1;
     }
+    return 0;
 }

--- a/list.c
+++ b/list.c
@@ -54,32 +54,31 @@ unsigned count_nodes(Head* head)
 
 int append_to_list(Head* head, unsigned size, void* data)
 {
-    if (head) 
+    if (!head)
     {
-        if (!(head->front)) 
-        {
-            head->front = create_node();
-            fill_node_data(head->front, size, data);
-        } 
-        else 
-        {
-            Node *this_node = head->front;
-            Node *next_node = get_next_node(this_node);
-            while (next_node) 
-            {
-                this_node = next_node;
-                next_node = get_next_node(next_node);
-            }
-            if (append_node(this_node, size, data)) 
-            {
-                return 1;
-            } 
-            else 
-            {
-                return 0;
-            }
-        }
-        return 1;
+        return 0;
     }
-    return 0;
+
+    if (!(head->front))
+    {
+        head->front = create_node();
+        fill_node_data(head->front, size, data);
+    }
+    else
+    {
+        Node* this_node = head->front;
+        Node* next_node = get_next_node(this_node);
+        while (next_node)
+        {
+            this_node = next_node;
+            next_node = get_next_node(next_node);
+        }
+
+        if (!append_node(this_node, size, data))
+        {
+            return 0;  // if append_node fails
+        }
+    }
+
+    return 1;  // if the operation is successful
 }

--- a/list.h
+++ b/list.h
@@ -9,6 +9,6 @@ typedef void(* list_func)(void*);
 Head* create_list(void);
 void destroy_list(Head* head);
 unsigned count_nodes(Head* head);
-void append_to_list(Head* head, unsigned size, void* data);
+int append_to_list(Head* head, unsigned size, void* data);
 
 #endif // LIST_H__


### PR DESCRIPTION
1. Implemented TODO: "check if `append_to_list` operation fails"
    - now this function will return a value either 0 or 1 that can be used to determine operation fail status
2. Auto-check if dependencies are installed
    - Auto-install all deps if they are missing
3. Instead of generating `coverage.info` in main directory, generate it inside `report` directory
    - First create `report` dir then generate `coverage.info` inside it
    - Directly remove `build` and `report` when user runs `make clean`