### PR TITLE
[issue #2] remove compiler warning for typedef'ed generic compare function and its specific implementation

### DIFF
--- a/main.c
+++ b/main.c
@@ -1,8 +1,34 @@
 #include <assert.h>
 #include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "node.h"
 #include "list.h"
+
+typedef struct Person
+{
+    char *name;
+    int age;
+} Person;
+
+// define compare_item_func_t as a function pointer type
+typedef _Bool (*compare_item_func_t)(void *, void *);
+
+// declare the compare_person function
+_Bool compare_person(Person *person1, Person *person2);
+
+// a wrapper function for compare_person that has the required signature
+_Bool compare_person_wrapper(void *item1, void *item2)
+{
+    return compare_person((Person *)item1, (Person *)item2);
+}
+
+#define NUM_ITEM_TYPES 1
+#define ITEM_TYPE_PERSON 0 // define ITEM_TYPE_PERSON with the appropriate value
+
+// define compare_item_func_list as a global variable
+compare_item_func_t compare_item_func_list[NUM_ITEM_TYPES] = {0};
 
 void create_node_tc(void)
 {
@@ -10,26 +36,21 @@ void create_node_tc(void)
     assert(NULL != node);
 
     char *node_data = "kei senpai";
-    fill_node_data(node, strlen(node_data)+1, node_data);
+    fill_node_data(node, strlen(node_data) + 1, node_data);
     char *saved_node_data = (char *)get_node_data(node);
-    
+
     assert(NULL != saved_node_data);
     assert(strlen(node_data) == strlen(saved_node_data));
     assert(0 == strncmp(saved_node_data, node_data, strlen(node_data)));
-    
+
     destroy_node(node);
 }
 
-typedef struct Person {
-    char* name;
-    int age;
-} Person;
-
-static void free_person_name(Person* person)
+static void free_person_name(Person *person)
 {
-    if(person)
+    if (person)
     {
-        if(person->name)
+        if (person->name)
         {
             free(person->name);
             person->name = NULL;
@@ -37,15 +58,21 @@ static void free_person_name(Person* person)
     }
 }
 
-static void* user_node_data_free_func(void* item)
+static void *user_node_data_free_func(void *item)
 {
-    free_person_name((Person*)item);
+    free_person_name((Person *)item);
     return NULL;
+}
+
+_Bool compare_person(Person *person1, Person *person2)
+{
+    // compare persons based on some criteria (here: compare by age)
+    return person1->age < person2->age;
 }
 
 void create_list_tc(void)
 {
-    Head* head = create_list();
+    Head *head = create_list();
     assert(NULL != head);
 
     Person person_list[] = {
@@ -60,8 +87,8 @@ void create_list_tc(void)
         {.name = strdup("Kelvin"), .age = 12},
     };
 
-    uint8_t person_list_len = sizeof(person_list)/sizeof(person_list[0]);
-    for(uint8_t i = 0; i < person_list_len; i++)
+    uint8_t person_list_len = sizeof(person_list) / sizeof(person_list[0]);
+    for (uint8_t i = 0; i < person_list_len; i++)
     {
         append_to_list(head, sizeof(Person), &person_list[i]);
     }
@@ -69,6 +96,10 @@ void create_list_tc(void)
     assert(person_list_len == count_nodes(head));
 
     set_user_data_free_func(user_node_data_free_func);
+
+    // update compare_item_func_list with the wrapper function
+    compare_item_func_list[ITEM_TYPE_PERSON] = compare_person_wrapper;
+
     destroy_list(head);
 }
 


### PR DESCRIPTION
Issue generated in #2 was due to a combination of missing declarations and incorrect function pointer assignments.

Error Identification: We encountered an error indicating an incompatible pointer type when initializing `compare_item_func_list`.

Understanding Error: Error message pointed to the `compare_item_func_list` initialization, suggesting an issue with the `compare_person` function pointer.

- Declaration of `compare_item_func_list`: We found that `compare_item_func_list` was not correctly declared. To address this, we defined `compare_item_func_t` as a function pointer type.

- Declaration of `compare_person`: We noticed that the `compare_person` function was missing its declaration. We added the declaration of `compare_person` before the `compare_person_wrapper` function.

- Modification of Wrapper Function: We modified the `compare_person_wrapper` function to have the correct signature and included the call to the `compare_person` function.

- Definition of `compare_person`: Finally, we added the implementation of the `compare_person` function based on the desired comparison criteria.