### PR TITLE
Makefile improvements for sonarqube

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,10 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Install sonar-scanner and build-wrapper
-        uses: SonarSource/sonarcloud-github-c-cpp@v1
+        uses: SonarSource/sonarcloud-github-c-cpp@v2.0.1
       - name: Run build-wrapper
         run: |
-          build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} make
+          build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} make sonarqube
       - name: Run sonar-scanner
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Install project dependencies
+        run: |
+          sudo apt update
+          sudo apt install valgrind lcov gcovr -y
       - name: Install sonar-scanner and build-wrapper
         uses: SonarSource/sonarcloud-github-c-cpp@v2.0.1
       - name: Run build-wrapper

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ COLOR_YELLOW=\033[1;33m
 COLOR_RESET=\033[0m
 
 CC = gcc
-CFLAGS = -Wall -Wextra -std=c11 -pedantic -g
+CFLAGS = -Wall -Wextra -std=c11 -pedantic -g  -D_XOPEN_SOURCE=600
+##TODO: use only c11 without gnu extensions or posix std (feature_test_macros(7))
 COVERAGE_CFLAGS = -fprofile-arcs -ftest-coverage
 COVERAGE_LFLAGS = -lgcov --coverage
 

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,6 @@ normal: $(BUILD_DIR)/main
 	valgrind --leak-check=full --show-leak-kinds=all --quiet $(BUILD_DIR)/main
 
 sonarqube:
-## Do not check for dependencies TODO:##should be managed by github actions workflow
+## Do not check for dependencies
 	@make clean $(MAKE_SUPPRESS_ENTER_LEAVE_DIR_MSG)
 	@make normal $(MAKE_SUPPRESS_ENTER_LEAVE_DIR_MSG)

--- a/Makefile
+++ b/Makefile
@@ -15,14 +15,16 @@ REPORT_DIR = report
 SOURCES = $(wildcard *.c)
 OBJECTS = $(SOURCES:%.c=$(BUILD_DIR)/%.o)
 
-all: check_dependencies $(BUILD_DIR)/main
-	@echo "$(COLOR_GREEN)============ RUNNING VALGRIND ============$(COLOR_RESET)"
-	valgrind --leak-check=full --show-leak-kinds=all --quiet $(BUILD_DIR)/main
+MAKE_SUPPRESS_ENTER_LEAVE_DIR_MSG = --no-print-directory
+
+all:
+	@make check_dependencies $(MAKE_SUPPRESS_ENTER_LEAVE_DIR_MSG)
+	@make normal $(MAKE_SUPPRESS_ENTER_LEAVE_DIR_MSG)
 
 check_dependencies:
+## This will only work for ubuntu. On Arch, libcheck is installed elsewhere.
 	@echo "$(COLOR_YELLOW)============ CHECKING DEPENDENCIES ============$(COLOR_RESET)"
 	@command -v valgrind > /dev/null || (echo "$(COLOR_RED)Valgrind is not installed. Installing...$(COLOR_RESET)" && sudo apt install -y valgrind)
-## This will only work for ubuntu. On Arch, libcheck is installed elsewhere.
 	@ls /usr/lib/x86_64-linux-gnu/ | grep libcheck.a > /dev/null || (echo "$(COLOR_RED)Check is not installed. Installing...$(COLOR_RESET)" && sudo apt install -y check)
 	@command -v lcov > /dev/null || (echo "$(COLOR_RED)Lcov is not installed. Installing...$(COLOR_RESET)" && sudo apt install -y lcov)
 	@command -v gcovr > /dev/null || (echo "$(COLOR_RED)Gcovr is not installed. Installing...$(COLOR_RESET)" && sudo apt install -y gcovr)
@@ -50,3 +52,13 @@ cov: $(BUILD_DIR)/main
 clean:
 	@echo "$(COLOR_YELLOW)============ CLEANING ============$(COLOR_RESET)"
 	rm -rf $(BUILD_DIR) $(REPORT_DIR)
+
+normal: $(BUILD_DIR)/main
+## Does not install dependencies
+	@echo "$(COLOR_GREEN)============ RUNNING VALGRIND ============$(COLOR_RESET)"
+	valgrind --leak-check=full --show-leak-kinds=all --quiet $(BUILD_DIR)/main
+
+sonarqube:
+## Do not check for dependencies TODO:##should be managed by github actions workflow
+	@make clean $(MAKE_SUPPRESS_ENTER_LEAVE_DIR_MSG)
+	@make normal $(MAKE_SUPPRESS_ENTER_LEAVE_DIR_MSG)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![SonarCloud](https://sonarcloud.io/images/project_badges/sonarcloud-black.svg)](https://sonarcloud.io/summary/new_code?id=devprabal_small-linklist)
+
 # Small linkedlist lib in C
 
 ## TODOs

--- a/main.c
+++ b/main.c
@@ -1,5 +1,7 @@
 #include <assert.h>
 #include <stdint.h>
+#include <string.h>
+#include <stdio.h>
 
 #include "node.h"
 #include "list.h"
@@ -83,7 +85,7 @@ static compare_item_func_t get_compare_item_func(ITEM_TYPE item_type)
 static size_t make_default_person_list(Head* head)
 {
     Person person_list[] = {
-        {.name = strdup("Kei"), .age = 26},
+        {.name = strdup("Kei"), .age = 26}, ////TODO: use a combination of malloc and memcpy instead of feature_test_macros. strdup is only availabe in c2x std
         {.name = strdup("Consti"), .age = 16},
         {.name = strdup("Midnight"), .age = 25},
         {.name = strdup("Nikhil"), .age = 18},

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=devprabal_small-linklist
 sonar.organization=devprabal
-
+sonar.cfamily.gcov.reportsPath=build
 # This is the name and version displayed in the SonarCloud UI.
 #sonar.projectName=small-linklist
 #sonar.projectVersion=1.0


### PR DESCRIPTION
- Enable new sonarqube github actions version (`sonarcloud-github-c-cpp@v2.0.1`) to remove `jdk-11` deprecation warning message
- Downgrade to C11 standard (from C2x) because sonarqube doesn't support C2x yet
- Enable `feature_test_macros` `_XOPEN_SOURCE=600` (`man 7`) for `strdup` since C11 doesn't include it in std library
- Add instructions in workflow file to install `valgrind`, `lcov`, and `gcov` dependencies on ubuntu (on github actions)
- Add coverage report generated by `gcov` to sonarqube (shows up on sonarcloud dashboard)